### PR TITLE
Add watch_avg command and Watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-amdgpu_fan
+/amdgpu_fan
 spec/examples.txt
 tmp
 *.gem

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -10,3 +10,4 @@ require_relative '../lib/amdgpu_fan/mixin/sys_write'
 
 require_relative '../lib/amdgpu_fan/service'
 require_relative '../lib/amdgpu_fan/cli'
+require_relative '../lib/amdgpu_fan/watcher'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -10,4 +10,5 @@ require_relative '../lib/amdgpu_fan/mixin/sys_write'
 
 require_relative '../lib/amdgpu_fan/service'
 require_relative '../lib/amdgpu_fan/cli'
+require_relative '../lib/amdgpu_fan/stat_set'
 require_relative '../lib/amdgpu_fan/watcher'

--- a/lib/amdgpu_fan/cli.rb
+++ b/lib/amdgpu_fan/cli.rb
@@ -116,11 +116,11 @@ module AmdgpuFan
         watcher.measure
         5.times { print "\033[K\033[A" } # move up a line and clear to end of line
 
-        puts "⏰ Core clock  " + watcher.core_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
-             "💾 Memory clk  " + watcher.mem_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
-             "🌀 Fan speed   " + watcher.fan_speed.map { |k,v| "#{k}: #{v} RPM ".ljust(16) }.join,
-             "🔌 Power usage " + watcher.power.map { |k,v| "#{k}: #{v} W ".ljust(16) }.join,
-             "🌡  Temperature " + watcher.temp.map { |k,v| "#{k}: #{v}°C ".ljust(16) }.join
+        puts "⏰ Core clock  " + watcher.core_clock.to_s,
+             "💾 Memory clk  " + watcher.mem_clock.to_s,
+             "🌀 Fan speed   " + watcher.fan_speed.to_s,
+             "🔌 Power usage " + watcher.power.to_s,
+             "🌡  Temperature " + watcher.temp.to_s
         sleep 1
       end
     end

--- a/lib/amdgpu_fan/cli.rb
+++ b/lib/amdgpu_fan/cli.rb
@@ -98,8 +98,7 @@ module AmdgpuFan
 
     desc 'watch_avg',
          <<~DOC
-           Watch min, man, and average fan speed, load, power, and temperature
-           refreshed every n seconds.
+           Watch min, max, average, and current stats.
          DOC
     def watch_avg
       puts "Watching #{amdgpu_service.name} min, max and averges since #{Time.now}...",

--- a/lib/amdgpu_fan/cli.rb
+++ b/lib/amdgpu_fan/cli.rb
@@ -117,11 +117,11 @@ module AmdgpuFan
         watcher.measure
         5.times { print "\033[K\033[A" } # move up a line and clear to end of line
 
-        puts "⏰ Core clock " + watcher.core_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
-             "💾 Memory clk " + watcher.mem_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
-             "🌀 Fan speed  " + watcher.fan_speed.map { |k,v| "#{k}: #{v} RPM ".ljust(16) }.join,
-             "🔌 Power usage" + watcher.power.map { |k,v| "#{k}: #{v} W ".ljust(16) }.join,
-             "🌡  Temperature" + watcher.temp.map { |k,v| "#{k}: #{v}°C ".ljust(16) }.join
+        puts "⏰ Core clock  " + watcher.core_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
+             "💾 Memory clk  " + watcher.mem_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
+             "🌀 Fan speed   " + watcher.fan_speed.map { |k,v| "#{k}: #{v} RPM ".ljust(16) }.join,
+             "🔌 Power usage " + watcher.power.map { |k,v| "#{k}: #{v} W ".ljust(16) }.join,
+             "🌡  Temperature " + watcher.temp.map { |k,v| "#{k}: #{v}°C ".ljust(16) }.join
         sleep 1
       end
     end

--- a/lib/amdgpu_fan/cli.rb
+++ b/lib/amdgpu_fan/cli.rb
@@ -96,6 +96,36 @@ module AmdgpuFan
       end
     end
 
+    desc 'watch_avg',
+         <<~DOC
+           Watch min, man, and average fan speed, load, power, and temperature
+           refreshed every n seconds.
+         DOC
+    def watch_avg
+      puts "Watching #{amdgpu_service.name} min, max and averges since #{Time.now}...",
+           '  <Press Ctrl-C to exit>',
+           "\n\n\n\n\n"
+
+      trap 'SIGINT' do
+        puts "\nAnd now the watch is ended."
+        exit 0
+      end
+
+      watcher = Watcher.new amdgpu_service
+
+      loop do
+        watcher.measure
+        5.times { print "\033[K\033[A" } # move up a line and clear to end of line
+
+        puts "⏰ Core clock " + watcher.core_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
+             "💾 Memory clk " + watcher.mem_clock.map { |k,v| "#{k}: #{v} MHz ".ljust(16) }.join,
+             "🌀 Fan speed  " + watcher.fan_speed.map { |k,v| "#{k}: #{v} RPM ".ljust(16) }.join,
+             "🔌 Power usage" + watcher.power.map { |k,v| "#{k}: #{v} W ".ljust(16) }.join,
+             "🌡  Temperature" + watcher.temp.map { |k,v| "#{k}: #{v}°C ".ljust(16) }.join
+        sleep 1
+      end
+    end
+
     desc 'watch_csv [SECONDS]', 'Watch stats in CSV format ' \
          'refreshed every n seconds defaulting to 1 second.'
     def watch_csv(seconds = 1)

--- a/lib/amdgpu_fan/stat_set.rb
+++ b/lib/amdgpu_fan/stat_set.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AmdgpuFan
+  # A set of stats
+  class StatSet < Hash
+    attr_accessor :avg, :max, :min, :now
+    attr_reader :unit
+
+    def initialize(unit)
+      @unit = unit
+    end
+
+    def stats
+      { min: min, avg: avg, max: max, now: now }
+    end
+
+    ##
+    # Return a string containing all the stats with units.
+    #
+    def to_s
+      stats.map { |k,v| "#{k}: #{v.to_s.rjust(6)} #{unit.ljust(3)} " }.join
+    end
+  end
+end

--- a/lib/amdgpu_fan/watcher.rb
+++ b/lib/amdgpu_fan/watcher.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module AmdgpuFan
+  # Keep track of stats over time.
+  class Watcher
+    attr_reader :core_clock, :fan_speed, :num_measurements, :mem_clock, :power, :temp
+
+    def initialize(amdgpu_service)
+      @amdgpu_service = amdgpu_service
+      @num_measurements = 0
+
+      @core_clock = { min: nil, avg: nil, max: nil, now: nil }
+      @mem_clock = { min: nil, avg: nil, max: nil, now: nil }
+      @fan_speed = { min: nil, avg: nil, max: nil, now: nil }
+      @power = { min: nil, avg: nil, max: nil, now: nil }
+      @temp = { min: nil, avg: nil, max: nil, now: nil }
+    end
+
+    ##
+    # Take a new set of measurements and adjust the stats.
+    #
+    def measure
+      @num_measurements += 1
+
+      @core_clock[:now] = @amdgpu_service.core_clock.to_i
+      @mem_clock[:now] = @amdgpu_service.memory_clock.to_i
+      @fan_speed[:now] = @amdgpu_service.fan_speed_rpm.to_i
+      @power[:now] = @amdgpu_service.power_draw.to_f
+      @temp[:now] = @amdgpu_service.temperature.to_i
+
+      [@core_clock, @mem_clock, @fan_speed, @power, @temp].each do |stat_set|
+        calculate_stats(stat_set)
+      end
+    end
+
+    private
+
+    def calculate_stats(stat_set)
+      if num_measurements == 1
+        stat_set[:min] = stat_set[:now]
+        stat_set[:avg] = stat_set[:now].to_f
+        stat_set[:max] = stat_set[:now]
+        return
+      end
+
+      stat_set[:min] = stat_set[:now] if stat_set[:now] < stat_set[:min]
+      stat_set[:avg] =
+       ((stat_set[:now] + stat_set[:avg] * (num_measurements - 1)) / num_measurements.to_f)
+         .round(1)
+      stat_set[:max] = stat_set[:now] if stat_set[:now] > stat_set[:max]
+    end
+  end
+end

--- a/lib/amdgpu_fan/watcher.rb
+++ b/lib/amdgpu_fan/watcher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'stat_set'
+
 module AmdgpuFan
   # Keep track of stats over time.
   class Watcher
@@ -9,11 +11,11 @@ module AmdgpuFan
       @amdgpu_service = amdgpu_service
       @num_measurements = 0
 
-      @core_clock = { min: nil, avg: nil, max: nil, now: nil }
-      @mem_clock = { min: nil, avg: nil, max: nil, now: nil }
-      @fan_speed = { min: nil, avg: nil, max: nil, now: nil }
-      @power = { min: nil, avg: nil, max: nil, now: nil }
-      @temp = { min: nil, avg: nil, max: nil, now: nil }
+      @core_clock = StatSet.new 'MHz'
+      @mem_clock = StatSet.new 'MHz'
+      @fan_speed = StatSet.new 'RPM'
+      @power = StatSet.new 'W'
+      @temp = StatSet.new '°C'
     end
 
     ##
@@ -22,11 +24,11 @@ module AmdgpuFan
     def measure
       @num_measurements += 1
 
-      @core_clock[:now] = @amdgpu_service.core_clock.to_i
-      @mem_clock[:now] = @amdgpu_service.memory_clock.to_i
-      @fan_speed[:now] = @amdgpu_service.fan_speed_rpm.to_i
-      @power[:now] = @amdgpu_service.power_draw.to_f
-      @temp[:now] = @amdgpu_service.temperature.to_i
+      @core_clock.now = @amdgpu_service.core_clock.to_i
+      @mem_clock.now = @amdgpu_service.memory_clock.to_i
+      @fan_speed.now = @amdgpu_service.fan_speed_rpm.to_i
+      @power.now = @amdgpu_service.power_draw.to_f
+      @temp.now = @amdgpu_service.temperature.to_i
 
       [@core_clock, @mem_clock, @fan_speed, @power, @temp].each do |stat_set|
         calculate_stats(stat_set)
@@ -37,17 +39,17 @@ module AmdgpuFan
 
     def calculate_stats(stat_set)
       if num_measurements == 1
-        stat_set[:min] = stat_set[:now]
-        stat_set[:avg] = stat_set[:now].to_f
-        stat_set[:max] = stat_set[:now]
+        stat_set.min = stat_set.now
+        stat_set.avg = stat_set.now.to_f
+        stat_set.max = stat_set.now
         return
       end
 
-      stat_set[:min] = stat_set[:now] if stat_set[:now] < stat_set[:min]
-      stat_set[:avg] =
-       ((stat_set[:now] + stat_set[:avg] * (num_measurements - 1)) / num_measurements.to_f)
+      stat_set.min = stat_set.now if stat_set.now < stat_set.min
+      stat_set.avg =
+       ((stat_set.now + stat_set.avg * (num_measurements - 1)) / num_measurements.to_f)
          .round(1)
-      stat_set[:max] = stat_set[:now] if stat_set[:now] > stat_set[:max]
+      stat_set.max = stat_set.now if stat_set.now > stat_set.max
     end
   end
 end

--- a/spec/lib/amdgpu_fan/watcher_spec.rb
+++ b/spec/lib/amdgpu_fan/watcher_spec.rb
@@ -5,17 +5,41 @@ require_relative '../../../lib/amdgpu_fan/watcher'
 require 'spec_helper'
 
 RSpec.describe AmdgpuFan::Watcher do
+  BASE_DIR = File.expand_path('../../../tmp', __dir__)
+  let(:file_dir) { "#{BASE_DIR}/card0/device" }
   let(:watcher) { described_class.new AmdgpuFan::Service.new }
+
+  before do
+    FileUtils.mkdir_p File.join(file_dir, 'hwmon/hwmon0')
+    stub_const "#{AmdgpuFan::Service}::BASE_FOLDER", BASE_DIR
+    File.write File.join(file_dir, 'pp_dpm_sclk'), <<~DOC
+      0: 852Mhz *
+      1: 991Mhz
+      2: 1084Mhz
+      3: 1138Mhz
+      4: 1200Mhz
+      5: 1401Mhz
+      6: 1536Mhz
+      7: 1630Mhz
+    DOC
+    File.write File.join(file_dir, 'pp_dpm_mclk'), <<~DOC
+      0: 167Mhz *
+      1: 500Mhz
+      2: 800Mhz
+      3: 945Mhz
+    DOC
+    File.write File.join(file_dir, 'hwmon/hwmon0/fan1_input'), 1207
+  end
 
   describe '#measure' do
     context 'when called the first time' do
       let(:blanks) { { avg: nil, max: nil, min: nil, now: nil } }
-      let(:core_stats) { { avg: 852.0, max: 852, min: 852, now: 852 } }
-      let(:fan_stats) { { avg: 1224.0, max: 1224, min: 1224, now: 1224 } }
+      let(:core_stats) { 'min:    852 MHz avg:  852.0 MHz max:    852 MHz now:    852 MHz ' }
+      let(:fan_stats) { 'min:   1207 RPM avg: 1207.0 RPM max:   1207 RPM now:   1207 RPM ' }
 
 
-      it { expect { watcher.measure }.to change(watcher, :core_clock).from(blanks).to(core_stats) }
-      it { expect { watcher.measure }.to change(watcher, :fan_speed).from(blanks).to(fan_stats) }
+      it { expect { watcher.measure }.to change { watcher.core_clock.to_s }.to(core_stats) }
+      it { expect { watcher.measure }.to change { watcher.fan_speed.to_s }.to(fan_stats) }
     end
   end
 end

--- a/spec/lib/amdgpu_fan/watcher_spec.rb
+++ b/spec/lib/amdgpu_fan/watcher_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/amdgpu_fan/service'
+require_relative '../../../lib/amdgpu_fan/watcher'
+require 'spec_helper'
+
+RSpec.describe AmdgpuFan::Watcher do
+  let(:watcher) { described_class.new AmdgpuFan::Service.new }
+
+  describe '#measure' do
+    context 'when called the first time' do
+      let(:blanks) { { avg: nil, max: nil, min: nil, now: nil } }
+      let(:core_stats) { { avg: 852.0, max: 852, min: 852, now: 852 } }
+      let(:fan_stats) { { avg: 1224.0, max: 1224, min: 1224, now: 1224 } }
+
+
+      it { expect { watcher.measure }.to change(watcher, :core_clock).from(blanks).to(core_stats) }
+      it { expect { watcher.measure }.to change(watcher, :fan_speed).from(blanks).to(fan_stats) }
+    end
+  end
+end

--- a/spec/lib/amdgpu_fan/watcher_spec.rb
+++ b/spec/lib/amdgpu_fan/watcher_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe AmdgpuFan::Watcher do
       3: 945Mhz
     DOC
     File.write File.join(file_dir, 'hwmon/hwmon0/fan1_input'), 1207
+    File.write File.join(file_dir, 'hwmon/hwmon0/power1_average'), 8000000
+    File.write File.join(file_dir, 'hwmon/hwmon0/temp1_input'), 25000
   end
 
   describe '#measure' do


### PR DESCRIPTION
```
➤  bin/amdgpu_fan watch_avg
Watching Sapphire Technology Limited Vega 10 XL/XT [Radeon RX Vega 56/64] min, max and averges since 2020-05-29 00:07:55 -0400...
  <Press Ctrl-C to exit>
⏰ Core clock  min: 852 MHz    avg: 1028.3 MHz max: 1536 MHz   now: 852 MHz
💾 Memory clk  min: 167 MHz    avg: 369.0 MHz  max: 945 MHz    now: 167 MHz
🌀 Fan speed   min: 1224 RPM   avg: 1224.0 RPM max: 1224 RPM   now: 1224 RPM
🔌 Power usage min: 9.0 W      avg: 74.9 W     max: 241.0 W    now: 11.0 W
🌡  Temperature min: 36°C       avg: 42.4°C     max: 51°C       now: 44°C
^C
And now the watch is ended.
```