### PR TITLE
Add Ruby 3.1 to RSpec CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.5
+    - name: Set up Ruby 3.1
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.5.x
+        ruby-version: 3.1.x
     - name: Install Dependencies
       run: |
         gem install bundler

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,12 +14,8 @@ jobs:
         os:
           - ubuntu
         ruby:
-          - "2.5"
-          - "2.6"
-          - "2.7"
-          - "3.0"
+          - "3.1"
           - "head"
-          - "jruby"
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:

--- a/lib/amdgpu_fan/stat_set.rb
+++ b/lib/amdgpu_fan/stat_set.rb
@@ -12,7 +12,7 @@ module AmdgpuFan
     end
 
     def stats
-      { min: min, avg: avg, max: max, now: now }
+      { min:, avg:, max:, now: }
     end
 
     ##

--- a/spec/lib/amdgpu_fan/service_spec.rb
+++ b/spec/lib/amdgpu_fan/service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
-
 require_relative '../../../lib/amdgpu_fan/service'
 require_relative '../../spec_helper'
 
@@ -235,5 +233,3 @@ RSpec.describe AmdgpuFan::Service do
     it { expect(amdgpu_service.vbios_version).to eq 'vbios version string' }
   end
 end
-
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Now that we require Ruby 3.1 CI needs to be updated.